### PR TITLE
Fix missing subject line border?

### DIFF
--- a/src/javascript/crypto/e2e/extension/ui/glass/composeglass.css
+++ b/src/javascript/crypto/e2e/extension/ui/glass/composeglass.css
@@ -144,7 +144,7 @@ textarea:focus,
   border: 0;
   display: inline-block;
   overflow: hidden;
-  padding: 0;
+  padding: 1px;
   padding-left: 8px;
 }
 


### PR DESCRIPTION
Some users apparently don't see the dividing line between the subject and body in compose glass. This might fix it. (Not sure because I haven't reproed this myself.)

Fix #17 
