### PR TITLE
Fix #20

### DIFF
--- a/src/javascript/crypto/e2e/extension/ui/panels/keyringmgmt/keyringmgmtmini_test.js
+++ b/src/javascript/crypto/e2e/extension/ui/panels/keyringmgmt/keyringmgmtmini_test.js
@@ -137,10 +137,6 @@ function testNonEmptyExport() {
 function testImportKeyring() {
   var filename = 'temp.asc';
   var importedFile = false;
-  stubs.replace(HTMLDivElement.prototype, 'querySelector', function(selector) {
-    return (selector === 'input') ? {files: [filename]} :
-        goog.dom.createElement('div');
-  });
 
   panel = new e2e.ext.ui.panels.KeyringMgmtMini(
       goog.abstractMethod, function(file) {
@@ -148,6 +144,11 @@ function testImportKeyring() {
         importedFile = true;
       }, goog.abstractMethod, goog.abstractMethod, goog.abstractMethod);
   panel.render(document.body);
+
+  stubs.replace(HTMLDivElement.prototype, 'querySelector', function(selector) {
+    return (selector === 'input') ? {files: [filename]} :
+        goog.dom.createElement('div');
+  });
 
   panel.importKeyring_();
   assertTrue(importedFile);


### PR DESCRIPTION
In recent versions of closure, stubbing out Element.prototype.querySelector
before rendering the component will cause some elements to not be rendered.

Fix #20
