### PR TITLE
Stub out cacheKeyData for now

### DIFF
--- a/src/javascript/crypto/e2e/extension/keyserver-client.js
+++ b/src/javascript/crypto/e2e/extension/keyserver-client.js
@@ -338,16 +338,12 @@ ext.keyserver.Client.prototype.safeDecode_ = function(str) {
 
 
 /**
- * Saves keydata entry to local storage.
+ * Saves keydata entry to local storage for pruning "expired" keys. This is
+ * just a placeholder method for now.
  * @param {string} response Response to cache.
  */
 ext.keyserver.Client.prototype.cacheKeyData = function(response) {
-  var responses = JSON.parse(window.localStorage.getItem(
-      constants.StorageKey.KEYSERVER_SIGNED_RESPONSES) || '[]') || [];
-  responses.push(response);
-  window.localStorage.setItem(
-      constants.StorageKey.KEYSERVER_SIGNED_RESPONSES,
-      JSON.stringify(responses));
+  return;
 };
 
 

--- a/src/javascript/crypto/e2e/extension/keyserver-client_test.js
+++ b/src/javascript/crypto/e2e/extension/keyserver-client_test.js
@@ -206,13 +206,6 @@ function testSendKey() {
 }
 
 
-function testCacheKeyData() {
-  client.cacheKeyData({foo: 'bar'});
-  assertArrayEquals([{foo: 'bar'}], JSON.parse(window.localStorage.getItem(
-      'keyserver-signed-responses')));
-}
-
-
 function testFetchAndImportKeys() {
   var userId = 'adhintz@google.com';
   var time = (new Date().getTime())/1000;

--- a/src/javascript/crypto/e2e/extension/ui/settings/settings_test.js
+++ b/src/javascript/crypto/e2e/extension/ui/settings/settings_test.js
@@ -132,7 +132,6 @@ function testGenerateKey() {
   window.setTimeout(function() {
     assertNotEquals(-1, document.body.textContent.indexOf(
         '<test@yahoo-inc.com>'));
-    assertNotNull(window.localStorage.getItem('keyserver-signed-responses'));
     testCase.continueTesting();
   }, 100);
 }


### PR DESCRIPTION
This is not used for anything at the moment. Also, it inadvertently causes
keyserver signed responses to be leaked into the localStorage context of Yahoo
mail.

Fix #5 
