### PR TITLE
Update config and instructions for OSS keyserver

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,16 +28,16 @@ Or, MacPorts:
 The extension requires a keyserver implementing [this API](docs/keyserver.md)
 to fetch keys for other users.
 
-We do not currently provide a publicly-exposed keyserver. So you'll need to run your own for now. (We will provide an open source vagrantfile or node package for this soon.)
+We do not currently provide a publicly-exposed keyserver, so for now the recommended way is to [follow these instructions](https://example.com) to run a local keyserver.
 
 Once that's done:
 
-1. Edit `src/javascript/crypto/e2e/extension/manifest.json` and replace
-   `https://keyshop.paranoids.corp.yahoo.com:25519` with the origin of your
-   keyserver.
-2. Edit `src/javascript/crypto/extension/config.js` with your keyserver
-   parameters. Most likely you will want to set `AUTH_ENABLED` to false, in
-   which case you can put anything for `AUTH_COOKIE` and `AUTH_DEFAULT_ORIGIN`.
+1. Replace `KAUTH_PUB` in `src/javascript/crypto/e2e/extension/config.js` with
+   the contents of `/path/to/keyshop/data/kauth/kauth.pub.js`.
+2. [OPTIONAL] If you're running the keyshop at a non-default origin, replace
+   `https://localhost:25519` with the keyserver origin in
+   `src/javascript/crypto/e2e/extension/config.js` and
+   `src/javascript/crypto/e2e/extension/manifest.json`.
 
 Then to build the extension:
 
@@ -45,7 +45,10 @@ Then to build the extension:
 
 ## Installation instructions
 
-Go to chrome://extensions, check the "developer mode" checkbox, click on "Load
+Go to `https://localhost:25519` in Chrome and click through the self-signed certificate
+warning so that the extension can talk to the keyserver.
+
+To load the extension, go to chrome://extensions, check the "developer mode" checkbox, click on "Load
 unpacked extension" and selected `file:///path/to/this/repo/build/extension`.
 
 

--- a/src/javascript/crypto/e2e/extension/config.js
+++ b/src/javascript/crypto/e2e/extension/config.js
@@ -25,11 +25,11 @@ e2e.ext.config = {
   /* The ECDSA pub key of the keyserver as a byte array */
   KAUTH_PUB: [4, 22, 240, 7, 228, 205, 195, 228, 101, 20, 52, 102, 64, 156, 187, 161, 103, 116, 56, 53, 184, 217, 167, 145, 0, 5, 253, 110, 141, 68, 125, 174, 234, 121, 214, 32, 3, 202, 137, 43, 233, 216, 49, 180, 106, 116, 245, 46, 53, 217, 249, 182, 122, 3, 164, 143, 107, 61, 144, 80, 103, 238, 192, 110, 54],
   /* The keyserver origin. Make sure you change this in manifest.json too */
-  TESTSERVER_ORIGIN: 'https://keyshop.paranoids.corp.yahoo.com:25519',
+  TESTSERVER_ORIGIN: 'https://localhost:25519',
   /* The name of the cookie used to authenticate users to the keyserver. */
-  AUTH_COOKIE: 'YBY',
+  AUTH_COOKIE: 'YOUR_COOKIE_HERE',
   /* Whether users need a valid auth cookie in order to use the keyserver */
-  AUTH_ENABLED: true,
+  AUTH_ENABLED: false,
   /* Some location that has access to the auth cookie. */
   AUTH_DEFAULT_ORIGIN: 'https://us-mg5.mail.yahoo.com'
 };

--- a/src/javascript/crypto/e2e/extension/manifest.json
+++ b/src/javascript/crypto/e2e/extension/manifest.json
@@ -8,7 +8,7 @@
     "cookies",
     "notifications",
     "tabs",
-    "https://keyshop.paranoids.corp.yahoo.com:25519/*",
+    "https://localhost:25519/*",
     "https://*.mail.yahoo.com/*"
   ],
   "optional_permissions": [],


### PR DESCRIPTION
We are pretty close to releasing the open sourcing a simple (no authentication required) keyserver, so I changed the default config and instructions to make it easier to build an extension that works with a local keyserver.

Before merging, note that "example.com" needs to be changed to the real location of the OSS keyserver github repo.
