### PR TITLE
Update for and pin to latest versions of dependencies

### DIFF
--- a/download-libs.sh
+++ b/download-libs.sh
@@ -25,12 +25,18 @@ cd lib
 
 # checkout closure library
 if [ ! -d closure-library/.git ]; then
-  git clone --depth 1 https://github.com/google/closure-library closure-library
+  git clone https://github.com/google/closure-library closure-library
+  cd closure-library
+  git checkout eb26f425dbd99a70d2955d8fcc892f2fd0178acb
+  cd ..
 fi
 
 # checkout zlib.js
 if [ ! -d zlib.js/.git ]; then
-  git clone --depth 1 https://github.com/imaya/zlib.js zlib.js
+  git clone https://github.com/imaya/zlib.js zlib.js
+  cd zlib.js
+  git checkout b99bd33d485d63e93310b911a1f8dbf9ceb265d5
+  cd ..
   mkdir typedarray
   ln -s ../zlib.js/define/typedarray/use.js typedarray/use.js
 fi
@@ -42,6 +48,7 @@ if [ ! -d closure-compiler/.git ]; then
   fi
   git clone --depth 1 https://github.com/google/closure-compiler closure-compiler
   cd closure-compiler
+  git checkout e7dc2720838d0c8fb14dbd31729b665c0b8735f4
   ant jar
   cd ..
 fi
@@ -60,6 +67,7 @@ if [ ! -d closure-stylesheets/.git ]; then
   fi
   git clone https://code.google.com/p/closure-stylesheets/
   cd closure-stylesheets
+  git checkout 3eb80f827270e73abd882ba69dbc3f3182a55889
   ant
   cp build/closure-stylesheets.jar ../
   cd ..

--- a/src/javascript/crypto/e2e/extension/helper/gmonkey.js
+++ b/src/javascript/crypto/e2e/extension/helper/gmonkey.js
@@ -95,7 +95,7 @@ gmonkey.isAvailable = function(callback) {
  * Gets the last selected message in Gmail.
  * @param {!function(Element)} callback The callback where the element
  *     containing the last selected message should be passed.
- * @expose
+ * @export
  */
 gmonkey.getCurrentMessage = function(callback) {
   gmonkey.callGmonkey_('getCurrentMessage', function(result) {
@@ -110,7 +110,7 @@ gmonkey.getCurrentMessage = function(callback) {
  * Gets the active draft in Gmail.
  * @param {!function(!Array.<string>,string)} callback The callback where the
  *     active draft information should be passed.
- * @expose
+ * @export
  * @suppress {missingProperties}
  */
 gmonkey.getActiveDraft = function(callback) {
@@ -141,7 +141,7 @@ gmonkey.getActiveDraft = function(callback) {
  * Indicates if there is an active draft in Gmail.
  * @param {!function(boolean)} callback The callback where the active draft
  *     information should be passed.
- * @expose
+ * @export
  */
 gmonkey.hasActiveDraft = function(callback) {
   gmonkey.callGmonkey_(
@@ -155,7 +155,7 @@ gmonkey.hasActiveDraft = function(callback) {
  * @param {string} msgBody The content body of the message.
  * @param {function()=} opt_callback Optional. A callback to invoke once the
  *     draft's contents have been set.
- * @expose
+ * @export
  */
 gmonkey.setActiveDraft = function(recipients, msgBody, opt_callback) {
   var callback = goog.nullFunction;

--- a/src/javascript/crypto/e2e/extension/launcher.js
+++ b/src/javascript/crypto/e2e/extension/launcher.js
@@ -88,7 +88,7 @@ ext.Launcher = function() {
  * @param {!function(...)} callback The function to invoke once the content has
  *     been updated.
  * @param {string=} opt_subject The subject of the message if applicable.
- * @expose
+ * @export
  */
 ext.Launcher.prototype.updateSelectedContent =
     function(content, recipients, origin, expectMoreUpdates,
@@ -111,7 +111,7 @@ ext.Launcher.prototype.updateSelectedContent =
  * Retrieves the content that the user has selected.
  * @param {!function(...)} callback The callback where the selected content will
  *     be passed.
- * @expose
+ * @export
  */
 ext.Launcher.prototype.getSelectedContent = function(callback) {
   this.getActiveTab_(goog.bind(function(tabId) {
@@ -170,7 +170,7 @@ ext.Launcher.prototype.getActiveTab_ = function(callback, opt_runHelper) {
  * Asks for the keyring passphrase and start the launcher. Will throw an
  * exception if the password is wrong.
  * @param {string=} opt_passphrase The passphrase of the keyring.
- * @expose
+ * @export
  */
 ext.Launcher.prototype.start = function(opt_passphrase) {
   this.start_(opt_passphrase || '');
@@ -305,7 +305,7 @@ ext.Launcher.prototype.executeRequest_ = function(args, tabId) {
 /**
  * Returns the PGP context used within the extension.
  * @return {e2e.openpgp.Context} The PGP context.
- * @expose
+ * @export
  */
 ext.Launcher.prototype.getContext = function() {
   return this.pgpContext_;
@@ -315,7 +315,7 @@ ext.Launcher.prototype.getContext = function() {
 /**
  * Indicates if the keyring was loaded with the correct passphrase.
  * @return {boolean} True if the keyring was loaded with the correct passphrase.
- * @expose
+ * @export
  */
 ext.Launcher.prototype.hasPassphrase = function() {
   return this.started_;

--- a/src/javascript/crypto/e2e/openpgp/context.js
+++ b/src/javascript/crypto/e2e/openpgp/context.js
@@ -69,13 +69,13 @@ e2e.openpgp.Context.KeyType = {
 /**
  * @param {string} passphrase The passphrase for encrypting the KeyRing
  *     when stored locally.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.setKeyRingPassphrase;
 
 
 /**
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.unsetKeyringPassphrase;
 
@@ -83,21 +83,21 @@ e2e.openpgp.Context.prototype.unsetKeyringPassphrase;
 /**
  * @param {string} passphrase Change the passphrase for encrypting the KeyRing
  *     when stored locally. Empty string for unencrypted.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.changeKeyRingPassphrase;
 
 
 /**
  * @return {boolean} True if there is a correct keyring passphrase set.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.hasPassphrase;
 
 
 /**
  * @return {boolean} True if the keyring is encrypted in LocalStorage.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.isKeyRingEncrypted;
 
@@ -106,7 +106,7 @@ e2e.openpgp.Context.prototype.isKeyRingEncrypted;
  * Parses key blocks and returns a structured description of the keys.
  * @param {!e2e.ByteArray|string} key Key(s) to get the description of.
  * @return {!e2e.openpgp.KeyResult} Description of the keys.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.getKeyDescription;
 
@@ -118,7 +118,7 @@ e2e.openpgp.Context.prototype.getKeyDescription;
  * @param {!e2e.ByteArray|string} key The key to import.
  * @return {!e2e.openpgp.ImportKeyResult} List of user IDs that were
  *     successfully imported.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.importKey;
 
@@ -134,7 +134,7 @@ e2e.openpgp.Context.prototype.importKey;
  * @param {string} email The email to associate the key to.
  * @param {number} expirationDate Timestamp in seconds to expire the key.
  * @return {!e2e.openpgp.GenerateKeyResult} The generated key.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.generateKey;
 
@@ -151,7 +151,7 @@ e2e.openpgp.Context.prototype.generateKey;
  *     the message with.
  * @return {!e2e.openpgp.EncryptSignResult} The result of the encrypt/sign
  *     operation.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.encryptSign;
 
@@ -164,7 +164,7 @@ e2e.openpgp.Context.prototype.encryptSign;
  *     a cleartext message).
  * @return {!e2e.openpgp.VerifyDecryptResult} The result of the
  *     verify/decrypt operation.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.verifyDecrypt;
 
@@ -173,7 +173,7 @@ e2e.openpgp.Context.prototype.verifyDecrypt;
  * Searches a public key from a user identifier.
  * @param {string} uid The user id to search for.
  * @return {!e2e.openpgp.KeyResult} The result of the key search.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.searchPublicKey;
 
@@ -182,7 +182,7 @@ e2e.openpgp.Context.prototype.searchPublicKey;
  * Searches a private key from a user identifier.
  * @param {string} uid The user id to search for.
  * @return {!e2e.openpgp.KeyResult} The result of the key search.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.searchPrivateKey;
 
@@ -191,7 +191,7 @@ e2e.openpgp.Context.prototype.searchPrivateKey;
  * Searches a public and private key from a user identifier.
  * @param {string} uid The user id to search for.
  * @return {!e2e.openpgp.KeyResult} The result of the key search.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.searchKey;
 
@@ -201,7 +201,7 @@ e2e.openpgp.Context.prototype.searchKey;
  * @param {boolean=} opt_priv Whether to return the private keyring.
  * @return {!e2e.async.Result.<!e2e.openpgp.KeyRingMap>} A clone of the key ring
  *     map.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.getAllKeys;
 
@@ -209,7 +209,7 @@ e2e.openpgp.Context.prototype.getAllKeys;
 /**
  * Deletes all keys for a user identifier.
  * @param {string} uid The user id to delete all keys.
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.deleteKey;
 
@@ -218,7 +218,7 @@ e2e.openpgp.Context.prototype.deleteKey;
  * Exports the secret keyring.
  * @param {boolean} armored Whether to export the keyring in radix64 armor.
  * @return {!e2e.async.Result.<!e2e.ByteArray|string>}
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.exportKeyring;
 
@@ -226,7 +226,7 @@ e2e.openpgp.Context.prototype.exportKeyring;
 /**
  * Provides serialized data needed to back up generated EC keys.
  * @return {!e2e.async.Result.<e2e.openpgp.KeyringBackupInfo>}
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.getKeyringBackupData;
 
@@ -236,7 +236,7 @@ e2e.openpgp.Context.prototype.getKeyringBackupData;
  * @param {e2e.openpgp.KeyringBackupInfo} data Serialized data to restore
  * @param {string} email The email to associate with restored keys.
  * @return {e2e.async.Result.<undefined>}
- * @expose
+ * @export
  */
 e2e.openpgp.Context.prototype.restoreKeyring;
 


### PR DESCRIPTION
Removed some warnings caused by new `closure-compiler` versions, and pinned all the dependencies from GitHub to particular known good Git revisions.
